### PR TITLE
update:GitHub Actionsのエラー対処”

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      
+      - name: Install Ruby Gems (explicitly for scan_js)
+        run: bundle install --jobs 4 --retry 3
 
       - name: Make bin scripts executable for scan_js
         run: chmod +x bin/*


### PR DESCRIPTION
## 概要
scan_js ジョブで importmap-rails gem が利用可能になるようにしました。