### PR TITLE
update:GitHub Actionsのエラー対処

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
           node-version: '20'
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
-        run: bin/rails importmap audit 
+        run: bundle exec rails importmap audit
+        shell: bash 
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 内容
- CI環境でbin/railsがBundlerのGemパスを完全に解決できない場合があるため、bundle execを明示することで、importmap-rails Gemが確実にロードされるようにしました。
- コマンドの実行シェルをbashに統一することで、環境による挙動の差異を防ぎぐようにしました。