### PR TITLE
Fix: Pin tailwindcss-rails to 3.x and update Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-gem "tailwindcss-rails"
+gem "tailwindcss-rails", "~> 3.3.1"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,16 +288,14 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
-    tailwindcss-rails (4.2.3)
+    tailwindcss-rails (3.3.2)
       railties (>= 7.0.0)
-      tailwindcss-ruby (~> 4.0)
-    tailwindcss-ruby (4.1.10)
-    tailwindcss-ruby (4.1.10-aarch64-linux-gnu)
-    tailwindcss-ruby (4.1.10-aarch64-linux-musl)
-    tailwindcss-ruby (4.1.10-arm64-darwin)
-    tailwindcss-ruby (4.1.10-x86_64-darwin)
-    tailwindcss-ruby (4.1.10-x86_64-linux-gnu)
-    tailwindcss-ruby (4.1.10-x86_64-linux-musl)
+      tailwindcss-ruby (~> 3.0)
+    tailwindcss-ruby (3.4.17-aarch64-linux)
+    tailwindcss-ruby (3.4.17-arm-linux)
+    tailwindcss-ruby (3.4.17-arm64-darwin)
+    tailwindcss-ruby (3.4.17-x86_64-darwin)
+    tailwindcss-ruby (3.4.17-x86_64-linux)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -349,7 +347,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails
+  tailwindcss-rails (~> 3.3.1)
   turbo-rails
   tzinfo-data
   web-console


### PR DESCRIPTION
## 概要
Renderにて`gem tailwindcss`のバージョンでエラーが出たため、明示的にGemfileにバージョンを設定しました。