### PR TITLE
add:Tailwindの入力パスを指定

### DIFF
--- a/config/initializers/tailwindcss.rb
+++ b/config/initializers/tailwindcss.rb
@@ -1,0 +1,1 @@
+Rails.application.config.tailwindcss.input = Rails.root.join("app", "assets", "tailwind", "application.css")


### PR DESCRIPTION
## 概要
Renderデプロイ時にTailwindCSS関連ファイルが見つからないというエラーが出たため、入力パスを指定しました。