### PR TITLE
update:index.jsの明示解除

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,5 +1,6 @@
 pin "application", preload: true
-pin "controllers", to: "controllers/index.js"
 
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
+
+pin "before_home_accordion_controller", to: "controllers/before_home_accordion_controller.js"


### PR DESCRIPTION
## 概要
Renderにてindex.jsが見つからないエラーが出ており、存在しないため明示していたコードを書き換えました