### PR TITLE
add:ストーリー編集ページの追加

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,6 +1,6 @@
 class StoriesController < ApplicationController
   before_action :require_login
-  before_action :set_story, only: [ :show, :set_status, :destroy ]
+  before_action :set_story, only: [ :show, :set_status, :destroy, :edit, :update ]
 
   def index
     @stories = current_user.stories.order(updated_at: :desc)
@@ -26,6 +26,18 @@ class StoriesController < ApplicationController
   def destroy
     @story.destroy
     redirect_to stories_path, notice: "ストーリー「#{@story.title}」を削除しました。", status: :see_other
+  end
+
+  def edit
+  end
+
+  def update
+    if @story.update(story_params)
+      redirect_to story_path(@story), success: "ストーリー「#{@story.title}」を更新しました。"
+    else
+      flash.now[:error] = "ストーリーの更新に失敗しました。"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def set_status

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,0 +1,39 @@
+<%= form_with model: story, local: true, class: "space-y-6" do |f| %>
+  <% if story.errors.any? %>
+    <div id="error_explanation" class="text-red-600 border border-red-300 bg-red-50 p-4 rounded-md">
+      <h2 class="font-bold text-lg mb-2"><%= story.errors.count %>件のエラーがあります。</h2>
+      <ul>
+        <% story.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :title, "タイトル", class: "block text-lg font-bold" %>
+    <%= f.text_field :title, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-black focus:border-black" %>
+  </div>
+
+  <div>
+    <%= f.label :genre, "ジャンル", class: "block text-lg font-bold" %>
+    <%= f.select :genre, options_for_select(Story.genres.keys.map { |k| [t("activerecord.attributes.story.genres.#{k}"), k] }, f.object.genre),
+      { include_blank: "ジャンルを選択してください。" },
+      class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-black focus:border-black" %>
+  </div>
+
+  <div>
+    <%= f.label :thema, "テーマ", class: "block text-lg font-bold" %>
+    <%= f.text_field :thema, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-black focus:border-black" %>
+  </div>
+
+  <div>
+    <%= f.label :synopsis, "あらすじ", class: "block text-lg font-bold" %>
+    <%= f.text_area :synopsis, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-black focus:border-black h-32", placeholder: "あらすじを記入してください。（あとから記入しても構いません）" %>
+  </div>
+
+  <div class="pt-4">
+    <% submit_text = f.object.new_record? ? "ストーリーをはじめる！" : "ストーリーを編集する" %>
+    <%= f.submit submit_text, class: "w-full py-3 px-4 border border-transparent rounded-md shadow-sm text-lg font-medium text-white bg-black hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,0 +1,8 @@
+<% breadcrumb :edit_story, @story %>
+<div class="px-4 sm:px-6 lg:px-8 py-8">
+  <div class="max-w-3xl mx-auto">
+    <div class="max-w-3xl mx-auto p-8 border-2 rounded-lg mb-14 border-black">
+      <%= render 'form', story: @story %>
+    </div>
+  </div>
+</div>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -2,45 +2,8 @@
   <div class="max-w-screen-xl mx-auto">
     <h1 class="text-center text-4xl font-bold tracking-tight mt-12 mb-20">あなただけのストーリーをはじめましょう！</h1>
 
-    <div class="max-w-3xl mx-auto p-8 border-2 rounded-lg mb-14">
-      <%= form_with model: @story, url: stories_path, local: true, class: "space-y-6" do |f| %>
-        <% if @story.errors.any? %>
-          <div id="error_explanation" class="text-red-600 border border-red-300 bg-red-50 p-4 rounded-md">
-            <h2 class="font-bold text-lg mb-2"><%= @story.errors.count %>件のエラーがあります。</h2>
-            <ul>
-              <% @story.errors.full_messages.each do |message| %>
-                <li><%= message %></li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
-
-        <div>
-          <%= f.label :title, "タイトル", class: "block text-lg font-bold text-gray-700" %>
-          <%= f.text_field :title, class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "タイトルを記入してください。" %>
-        </div>
-
-        <div>
-          <%= f.label :genre, "ジャンル", class: "block text-lg font-bold text-gray-700" %>
-          <%= f.select :genre, options_for_select(Story.genres.keys.map { |k| [t("activerecord.attributes.story.genres.#{k}"), k] }, f.object.genre),
-            { include_blank: "ジャンルを選択してください。" },
-            class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
-        </div>
-
-        <div>
-          <%= f.label :thema, "テーマ", class: "block text-lg font-bold text-gray-700" %>
-          <%= f.text_field :thema, class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "30文字以内でテーマを記入してください。" %>
-        </div>
-
-        <div>
-          <%= f.label :synopsis, "あらすじ", class: "block text-lg font-bold text-gray-700" %>
-          <%= f.text_area :synopsis, class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 h-32", placeholder: "あらすじを記入してください。（あとから記入しても構いません）" %>
-        </div>
-
-        <div class="pt-4">
-          <%= f.submit "ストーリーをはじめる！", class: "w-full py-3 px-4 border border-transparent rounded-md shadow-sm text-lg font-medium text-white bg-black hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black cursor-pointer" %>
-        </div>
-      <% end %>
+    <div class="max-w-3xl mx-auto p-8 border-2 rounded-lg mb-14 border-black">
+      <%= render 'form', story: @story %>
     </div>
   </div>
 </div>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -57,7 +57,9 @@
       </div>
 
       <div class="flex justify-center mt-8">
-        <%= link_to "ストーリーを編集する", "#", class: "border border-gray-400 px-4 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors duration-300" %>
+        <%= link_to "ストーリーを編集する", edit_story_path(@story),
+          class: "border border-gray-400 px-4 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors duration-300",
+          data: { turbo: false } %>
       </div>
     </div>
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -6,3 +6,8 @@ crumb :story do |story|
   link truncate(story.title, length: 10), story_path(story)
   parent :stories
 end
+
+crumb :edit_story do |story|
+  link "ストーリー編集", edit_story_path(story)
+  parent :story, story
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  resources :stories, only: [ :index, :new, :create, :show, :destroy ] do
+  resources :stories, only: [ :index, :new, :create, :show, :destroy, :edit, :update ] do
     member do
       patch "set_status"
     end


### PR DESCRIPTION
## 概要
ストーリー編集ページを実装しました。

## 内容
- ストーリー詳細ページの編集ボタンより遷移できるようにしました。
- ストーリー作成ページとレイアウトが似通っているので共通箇所を別ファイルにまとめました。（app/views/stories/_form.html.erb）