### PR TITLE
add:プロット一覧・作成機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,10 @@ class ApplicationController < ActionController::Base
   def logged_in?
     !current_user.nil?
   end
+
+  def require_login
+    unless logged_in?
+      redirect_to root_path, alert: "ログインしてください"
+    end
+  end
 end

--- a/app/controllers/plots_controller.rb
+++ b/app/controllers/plots_controller.rb
@@ -1,0 +1,28 @@
+class PlotsController < ApplicationController
+  before_action :require_login
+  before_action :set_story
+
+  def new
+    @plot = @story.plots.build
+  end
+
+  def create
+    @plot = @story.plots.build(plot_params)
+    if @plot.save
+      redirect_to story_path(@story), success: "プロットを追加しました。"
+    else
+      flash.now[:error] = "プロットの作成に失敗しました。"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_story
+    @story = current_user.stories.find(params[:story_id])
+  end
+
+  def plot_params
+    params.require(:plot).permit(:chapter, :title, :summary, :content, :order)
+  end
+end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -51,12 +51,6 @@ class StoriesController < ApplicationController
 
   private
 
-  def require_login
-    unless logged_in?
-      redirect_to root_path, alert: "ログインしてください"
-    end
-  end
-
   def set_story
     @story = current_user.stories.find(params[:id])
   end

--- a/app/helpers/plots_helper.rb
+++ b/app/helpers/plots_helper.rb
@@ -1,0 +1,2 @@
+module PlotsHelper
+end

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -1,0 +1,5 @@
+class Plot < ApplicationRecord
+  belongs_to :story, touch: true
+
+  validates :chapter, presence: true
+end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,6 +1,7 @@
 class Story < ApplicationRecord
   attribute :status, :integer, default: 0
   belongs_to :user
+  has_many :plots, dependent: :destroy
 
   enum status: { draft: 0, published: 1 }
 
@@ -10,6 +11,8 @@ class Story < ApplicationRecord
     romance: "恋愛",
     mystery: "ミステリー",
     horror: "ホラー",
+    history: "歴史",
+    contemporary: "現代小説",
     other: "その他"
   }
 

--- a/app/views/plots/_form.html.erb
+++ b/app/views/plots/_form.html.erb
@@ -1,0 +1,63 @@
+<%= form_with model: [story, plot], local: true, class: "space-y-8" do |f| %>
+
+  <% if plot.errors.any? %>
+    <div id="error_explanation" class="text-red-600 border border-red-300 bg-red-50 p-4 rounded-md">
+      <h2 class="font-bold text-lg mb-2"><%= plot.errors.count %>件のエラーがあります。</h2>
+      <ul>
+        <% plot.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :chapter, "章", class: "block text-lg font-bold" %>
+    <%= f.text_field :chapter, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm", placeholder: "第一章、プロローグなど" %>
+  </div>
+
+  <div>
+    <%= f.label :title, "タイトル", class: "block text-lg font-bold" %>
+    <%= f.text_field :title, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm", placeholder: "タイトルを記入してください。" %>
+  </div>
+
+  <div>
+    <%= f.label :summary, "要約", class: "block text-lg font-bold" %>
+    <%= f.text_field :summary, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm", placeholder: "30文字以内で記入してください。" %>
+  </div>
+  
+  <div>
+    <label class="block text-lg font-bold">ワールドガイド</label>
+    <select disabled class="mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm bg-gray-100 text-gray-500">
+      <option>作成したワールドガイドを選択できます。ワールドガイドを作成してください。</option>
+    </select>
+  </div>
+  <div>
+    <label class="block text-lg font-bold">キャラクター</label>
+    <select disabled class="mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm bg-gray-100 text-gray-500">
+      <option>作成したキャラクターを選択できます。キャラクターを作成してください。</option>
+    </select>
+  </div>
+  <div>
+    <label class="block text-lg font-bold">フラグ</label>
+    <select disabled class="mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm bg-gray-100 text-gray-500">
+      <option>作成したフラグを選択できます。フラグを作成してください。</option>
+    </select>
+  </div>
+
+  <div>
+    <%= f.label :content, "構成メモ", class: "block text-lg font-bold" %>
+    <select disabled class="mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm bg-gray-100 text-gray-500 mb-2">
+      <option>テンプレートを選択し追加することも可能です。</option>
+    </select>
+    <%= f.text_area :content, class: "mt-1 block w-full px-3 py-2 border border-black rounded-md shadow-sm h-48", placeholder: "登録した要素を基に本編のメモ書きとしてご利用ください。" %>
+  </div>
+
+  <div class="flex justify-center items-center gap-4 pt-4">
+    <button type="button" disabled class="w-1/2 py-3 px-4 border rounded-md shadow-sm text-lg font-medium text-gray-500 bg-gray-100">
+      AIプロットチェック
+    </button>
+    <%= f.submit "プロットを作成", class: "w-1/2 py-3 px-4 border border-transparent rounded-md shadow-sm text-lg font-medium text-white bg-black hover:bg-gray-700 cursor-pointer" %>
+  </div>
+
+<% end %>

--- a/app/views/plots/new.html.erb
+++ b/app/views/plots/new.html.erb
@@ -1,0 +1,8 @@
+<% breadcrumb :new_plot, @story %>
+<div class="px-4 sm:px-6 lg:px-8 py-8">
+  <div class="max-w-3xl mx-auto">
+    <div class="p-8">
+      <%= render 'form', story: @story, plot: @plot %>
+    </div>
+  </div>
+</div>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -65,11 +65,64 @@
 
     <div class="mt-12">
       <p class="font-bold text-lg mb-2">■ プロット</p>
-
       <div class="border-2 rounded-lg p-8 border-black">
 
-        <div class="flex justify-center mt-2">
-          <%= link_to "プロットに追加する", "#", class: "border border-gray-400 px-4 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors duration-300" %>
+        <div class="space-y-6">
+          <% if @story.plots.any? %>
+            <% @story.plots.order(:order, :created_at).each do |plot| %>
+              <div class="border rounded-lg p-6 space-y-4">
+
+                <div class="flex items-baseline">
+                  <span class="font-bold text-xl mr-2">【<%= plot.chapter %>】</span>
+                  <span class="text-xl"><%= plot.title %></span>
+                </div>
+
+                <div>
+                  <p class="font-bold">【要約】</p>
+                  <p class="ml-4 text-gray-700"><%= plot.summary %></p>
+                </div>
+
+                <div>
+                  <p class="font-bold">【ワールドガイド】</p>
+                  <div class="flex flex-wrap gap-2 mt-2 ml-4">
+                    <span class="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded-full">（未実装）</span>
+                  </div>
+                </div>
+
+                <div>
+                  <p class="font-bold">【キャラクター】</p>
+                  <div class="flex flex-wrap gap-2 mt-2 ml-4">
+                     <span class="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded-full">（未実装）</span>
+                  </div>
+                </div>
+
+                <div>
+                  <p class="font-bold">【フラグ】</p>
+                  <div class="flex flex-wrap gap-2 mt-2 ml-4">
+                    <span class="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded-full">（未実装）</span>
+                  </div>
+                </div>
+
+                <div>
+                  <p class="font-bold">【構成メモ】</p>
+                  <div class="ml-4 mt-1 text-gray-700 prose max-w-none">
+                    <%= simple_format(plot.content) %>
+                  </div>
+                </div>
+            
+                <div class="flex justify-end items-center gap-4 mt-6">
+                  <%= link_to "編集する", "#", class: "border border-gray-400 bg-white px-8 py-2 rounded-md font-semibold hover:bg-gray-100" %>
+                  <%= link_to "削除する", "#", class: "border border-gray-400 px-8 py-2 rounded-md font-semibold hover:bg-red-500 hover:text-white transition-colors duration-300" %>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <p class="text-center text-gray-500">まだプロットはありません。</p>
+          <% end %>
+        </div>
+
+        <div class="flex justify-center mt-8">
+          <%= link_to "プロットに追加する", new_story_plot_path(@story), class: "border border-gray-400 px-4 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors duration-300" %>
         </div>
       </div>
     </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -11,3 +11,8 @@ crumb :edit_story do |story|
   link "ストーリー編集", edit_story_path(story)
   parent :story, story
 end
+
+crumb :new_plot do |story|
+  link "プロット作成", new_story_plot_path(story)
+  parent :story, story
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,11 @@ ja:
           romance: "恋愛"
           mystery: "ミステリー"
           horror: "ホラー"
+          history: "歴史"
+          contemporary: "現代小説"
           other: "その他"
+      plot:
+        chapter: "「 章 」"
 
   time:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     member do
       patch "set_status"
     end
+    resources :plots, only: [ :new, :create ]
   end
 
   root "home#index"

--- a/db/migrate/20250626022728_create_plots.rb
+++ b/db/migrate/20250626022728_create_plots.rb
@@ -1,0 +1,14 @@
+class CreatePlots < ActiveRecord::Migration[7.2]
+  def change
+    create_table :plots do |t|
+      t.string :chapter
+      t.string :title
+      t.string :summary
+      t.text :content
+      t.integer :order
+      t.references :story, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_24_085945) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_26_022728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "plots", force: :cascade do |t|
+    t.string "chapter"
+    t.string "title"
+    t.string "summary"
+    t.text "content"
+    t.integer "order"
+    t.bigint "story_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_id"], name: "index_plots_on_story_id"
+  end
 
   create_table "stories", force: :cascade do |t|
     t.string "title"
@@ -35,5 +47,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_24_085945) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "plots", "stories"
   add_foreign_key "stories", "users"
 end

--- a/test/controllers/plots_controller_test.rb
+++ b/test/controllers/plots_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PlotsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/plots.yml
+++ b/test/fixtures/plots.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  chapter: MyString
+  title: MyString
+  summary: MyString
+  content: MyText
+  order: 1
+  story: one
+
+two:
+  chapter: MyString
+  title: MyString
+  summary: MyString
+  content: MyText
+  order: 1
+  story: two

--- a/test/models/plot_test.rb
+++ b/test/models/plot_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PlotTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
プロット作成機能を追加、ストーリー詳細ページにプロット一覧機能を追加しました。

## 内容
- Plotモデルの追加を行いました（事前ER図から`chapter`カラムを追加しました※章：string）
- ストーリー詳細ページにプロット一覧が表示されるよう実装しました
- 削除、編集、プロット作成ボタンをストーリー詳細ページに追加しました。