### PR TITLE
fix:Renderの初期データ投 入エラー2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@ db/schema.rb linguist-generated
 vendor/* linguist-vendored
 config/credentials/*.yml.enc diff=rails_credentials
 config/credentials.yml.enc diff=rails_credentials
+
+*.sh text eol=lf


### PR DESCRIPTION
## 概要
Render自動デプロイにて、Windows環境とLinux（Renderのコンテナが動いている環境）の改行コードの違いでエラーがでていたため、改行コードをLFに統一するよう実装しました。