### PR TITLE
add:キャラクター作成、詳細ページの実装

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -1,11 +1,62 @@
 class CharactersController < ApplicationController
   before_action :require_login
   before_action :set_story
+  before_action :set_character, only: [ :show, :edit, :update, :destroy ]
 
   def index
-    @characters = @story.characters.order(:created_at)
+    @characters = @story.characters.includes(character_features: :character_feature_category, relationships: :related_character).order(:created_at)
     @grouped_characters = @characters.group_by(&:category)
     @categories = Character.categories.keys
+  end
+
+  def show
+  end
+
+  def new
+    @character = @story.characters.build
+    @character.category = params[:character][:category] if params.dig(:character, :category)
+
+    @world_guides = @story.world_guides.order(:created_at)
+    @feature_categories = CharacterFeatureCategory.order(:id)
+    @characters_for_relation = @story.characters.where.not(id: @character.id).order(:created_at)
+  end
+
+  def create
+    @character = @story.characters.build(character_params)
+    if @character.save
+      redirect_to story_characters_path(@story), success: "キャラクターを追加しました。"
+    else
+      @world_guides = @story.world_guides
+      @feature_categories = CharacterFeatureCategory.all
+      @characters_for_relation = @story.characters.where.not(id: @character.id)
+
+      flash.now[:error] = "キャラクターの作成に失敗しました。"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @world_guides = @story.world_guides.order(:created_at)
+    @feature_categories = CharacterFeatureCategory.order(:id)
+    @characters_for_relation = @story.characters.where.not(id: @character.id).order(:created_at)
+  end
+
+  def update
+    if @character.update(character_params)
+      redirect_to story_character_path(@story, @character), success: "キャラクターを更新しました。"
+    else
+      @world_guides = @story.world_guides
+      @feature_categories = CharacterFeatureCategory.all
+      @characters_for_relation = @story.characters.where.not(id: @character.id)
+
+      flash.now[:error] = "キャラクターの更新に失敗しました。"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @character.destroy
+    redirect_to story_characters_path(@story), success: "キャラクターを削除しました。", status: :see_other
   end
 
   private
@@ -14,7 +65,16 @@ class CharactersController < ApplicationController
     @story = current_user.stories.find(params[:story_id])
   end
 
-  # def character_params
-  #   params.require(:character).permit(:name, :race, :gender, :age, :category)
-  # end
+  def set_character
+    @character = @story.characters.find(params[:id])
+  end
+
+  def character_params
+    params.require(:character).permit(
+      :name, :race, :gender, :age, :category,
+      :birthplace_world_guide_id, :address_world_guide_id,
+      character_features_attributes: [ :id, :character_feature_category_id, :explanation, :_destroy ],
+      relationships_attributes: [ :id, :related_character_id, :relationship_type, :_destroy ]
+    )
+  end
 end

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -7,10 +7,9 @@ export default class extends Controller {
     "inputType", 
     "inputExplanation",
     "flashContainer",
-    "modalPlaceholder" // 1. モーダルの置き場所をターゲットに追加
+    "modalPlaceholder"
   ]
 
-  // (addメソッドは変更なし)
   add(event) {
     event.preventDefault()
     const categoryId = this.inputTypeTarget.value
@@ -31,32 +30,27 @@ export default class extends Controller {
     this.inputTypeTarget.selectedIndex = 0
   }
 
-
-  // --- ▼▼▼ removeメソッドと、そのヘルパーメソッドを修正 ▼▼▼ ---
   remove(event) {
     event.preventDefault()
     const wrapper = event.target.closest(".nested-fields-wrapper")
-    
-    // 削除の実行ロジックを定義
+
     const removalLogic = () => {
       if (wrapper.dataset.newRecord === "true") {
-        // 新しいレコードなら、要素ごと削除
+
         wrapper.remove()
       } else {
-        // 既存のレコードなら、非表示にして_destroyフラグを立てる
+
         wrapper.style.display = "none"
         const destroyInput = wrapper.querySelector("input[name*='_destroy']")
         destroyInput.value = "1"
       }
     }
 
-    // モーダルを表示して、OKが押されたら上記のロジックを実行する
     this.showConfirmationModal("この特徴を削除しますか？", removalLogic)
   }
 
-  // モーダルを動的に生成・表示するメソッド
   showConfirmationModal(message, callback) {
-    // 既存のモーダルがあれば消す
+
     this.hideConfirmationModal()
 
     const modalHTML = `
@@ -84,27 +78,23 @@ export default class extends Controller {
       </div>
     `
     this.modalPlaceholderTarget.innerHTML = modalHTML
-    // 「削除する」ボタンが押されたときに実行する処理を、一時的にコントローラに保存しておく
     this.confirmCallback = callback
   }
 
-  // モーダルを非表示にするメソッド
   hideConfirmationModal() {
     this.modalPlaceholderTarget.innerHTML = ""
     this.confirmCallback = null
   }
 
-  // モーダルの「削除する」ボタンが押されたときに呼ばれるメソッド
   confirmAndHide() {
-    // 保存しておいた削除処理を実行
+
     if (this.confirmCallback) {
       this.confirmCallback()
     }
-    // モーダルを閉じる
     this.hideConfirmationModal()
   }
 
-  // (showFlashメソッドは変更なし)
+
   showFlash(message) {
     const flashEl = document.createElement("div")
     flashEl.className = "p-3 bg-red-100 border border-red-400 text-red-700 rounded-md text-sm"

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,8 +1,18 @@
 class Character < ApplicationRecord
   belongs_to :story, touch: true
-
   belongs_to :birthplace_world_guide, class_name: "WorldGuide", optional: true
   belongs_to :address_world_guide, class_name: "WorldGuide", optional: true
+
+  has_many :character_features, dependent: :destroy
+  has_many :character_feature_categories, through: :character_features
+  accepts_nested_attributes_for :character_features, allow_destroy: true, reject_if: :all_blank
+
+  has_many :relationships, class_name: "CharacterRelationship", foreign_key: "character_id", dependent: :destroy, inverse_of: :character
+  has_many :related_characters, through: :relationships, source: :related_character
+
+  has_many :reverse_of_relationships, class_name: "CharacterRelationship", foreign_key: "related_character_id", dependent: :destroy
+  has_many :relating_characters, through: :reverse_of_relationships, source: :character
+  accepts_nested_attributes_for :relationships, allow_destroy: true, reject_if: proc { |attributes| attributes["relationship_type"].blank? }
 
   enum category: {
     present: "現在",
@@ -10,4 +20,14 @@ class Character < ApplicationRecord
     past: "過去",
     fantasy: "空想"
   }
+  enum gender: {
+    male: 0,
+    female: 1,
+    other: 2,
+    unknown: 99
+  }
+
+  validates :name, presence: true, length: { maximum: 30 }
+  validates :race, length: { maximum: 30 }
+  validates :age, length: { maximum: 20 }
 end

--- a/app/models/character_feature.rb
+++ b/app/models/character_feature.rb
@@ -1,0 +1,4 @@
+class CharacterFeature < ApplicationRecord
+  belongs_to :character
+  belongs_to :character_feature_category
+end

--- a/app/models/character_feature_category.rb
+++ b/app/models/character_feature_category.rb
@@ -1,0 +1,3 @@
+class CharacterFeatureCategory < ApplicationRecord
+  has_many :character_features, dependent: :destroy
+end

--- a/app/models/character_relationship.rb
+++ b/app/models/character_relationship.rb
@@ -1,0 +1,4 @@
+class CharacterRelationship < ApplicationRecord
+  belongs_to :character, class_name: "Character", inverse_of: :relationships
+  belongs_to :related_character, class_name: "Character", inverse_of: :reverse_of_relationships
+end

--- a/app/views/characters/_character_feature_fields.html.erb
+++ b/app/views/characters/_character_feature_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="nested-fields flex items-center gap-2 mb-2">
+  <%= f.collection_select :character_feature_category_id, @feature_categories, :id, :name, { prompt: "特徴を選択" }, { class: "w-1/2 p-2 border border-black rounded" } %>
+  <%= f.text_field :explanation, placeholder: "特徴の説明", class: "w-1/2 p-2 border border-black rounded" %>
+  <%= f.hidden_field :_destroy %>
+  <button type="button" data-action="nested-form#remove" class="text-red-500 hover:underline">削除</button>
+</div>

--- a/app/views/characters/_character_relationship_fields.html.erb
+++ b/app/views/characters/_character_relationship_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="nested-fields flex items-center gap-2 mb-2">
+  <%= f.collection_select :related_character_id, @characters_for_relation, :id, :name, { prompt: "関連するキャラクターを選択" }, { class: "w-1/2 p-2 border border-black rounded" } %>
+  <%= f.text_field :relationship_type, placeholder: "関係性（例：友人、ライバル）", class: "w-1/2 p-2 border border-black rounded" %>
+  <%= f.hidden_field :_destroy %>
+  <button type="button" data-action="nested-form#remove" class="text-red-500 hover:underline">削除</button>
+</div>

--- a/app/views/characters/_form.html.erb
+++ b/app/views/characters/_form.html.erb
@@ -1,0 +1,135 @@
+<%= form_with model: [story, character], local: true, class: "space-y-8" do |f| %>
+  <% if character.errors.any? %>
+    <div id="error_explanation" class="text-red-500 border border-red-300 bg-red-50 p-4 rounded-md">
+      <h2 class="font-bold text-lg mb-2"><%= character.errors.count %>件のエラーがあります。</h2>
+      <ul>
+        <% character.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :category, "カテゴリ", class: "block text-lg font-bold" %>
+    <%= f.select :category, Character.categories.keys.map { |k| [t("enums.character.category.#{k}"), k] }, { prompt: "カテゴリを選択してください" }, { class: "mt-2 w-full p-2 border border-black rounded" } %>
+  </div>
+
+  <div>
+    <%= f.label :name, "キャラクター名", class: "block text-lg font-bold" %>
+    <%= f.text_field :name, placeholder: "キャラクター名を記載してください", class: "mt-2 w-full p-2 border border-black rounded" %>
+  </div>
+  <div>
+    <%= f.label :race, "種族", class: "block text-lg font-bold" %>
+    <%= f.text_field :race, placeholder: "キャラクターの種族を記載してください", class: "mt-2 w-full p-2 border border-black rounded" %>
+  </div>
+  <div>
+    <%= f.label :gender, "性別", class: "block text-lg font-bold" %>
+    <%= f.select :gender, Character.genders.keys.map { |k| [I18n.t("enums.character.gender.#{k}"), k] }, { prompt: "キャラクターの性別を選択してください" }, { class: "mt-2 w-full p-2 border border-black rounded" } %>
+  </div>
+  <div>
+    <%= f.label :age, "年齢", class: "block text-lg font-bold" %>
+    <%= f.text_field :age, placeholder: "キャラクターの年齢を記載してください", class: "mt-2 w-full p-2 border border-black rounded" %>
+  </div>
+
+  <div>
+    <%= f.label :birthplace_world_guide_id, "出身地", class: "block text-lg font-bold" %>
+    <%= f.collection_select :birthplace_world_guide_id, @world_guides, :id, :country_and_region, { prompt: "作成済みのワールドガイドから選択してください" }, { class: "mt-2 w-full p-2 border border-black rounded" } %>
+  </div>
+  <div>
+    <%= f.label :address_world_guide_id, "現住所", class: "block text-lg font-bold" %>
+    <%= f.collection_select :address_world_guide_id, @world_guides, :id, :country_and_region, { prompt: "作成済みのワールドガイドから選択してください" }, { class: "mt-2 w-full p-2 border border-black rounded" } %>
+  </div>
+
+  <div data-controller="nested-form">
+    <p class="block text-lg font-bold mb-1">関連するキャラクター</p>
+    <div class="border rounded-lg p-4 mb-2 space-y-2">
+      <select data-nested-form-target="inputType" class="block w-full px-3 py-2 border border-black rounded-md">
+        <option value="">キャラクターを選択してください</option>
+        <% @characters_for_relation.each do |char| %>
+          <option value="<%= char.id %>" data-name="<%= char.name %>"><%= char.name %></option>
+        <% end %>
+      </select>
+      <input type="text" data-nested-form-target="inputExplanation" class="block w-full px-3 py-2 border border-black rounded-md" placeholder="関係性を記入してください（例：友人、ライバル）">
+      <button type="button" data-action="click->nested-form#add" class="border border-gray-400 w-full py-2 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300">関係性を追加</button>
+    </div>
+    <div data-nested-form-target="flashContainer" class="mb-4"></div>
+    <div data-nested-form-target="container" class="flex flex-wrap gap-2">
+      <%= f.fields_for :relationships do |relation_form| %>
+        <% unless relation_form.object.new_record? %>
+          <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove">
+            <span><%= relation_form.object.related_character.name %> / <%= relation_form.object.relationship_type %></span>
+            <span class="text-xs text-red-500 font-bold">×</span>
+            <%= relation_form.hidden_field :id %>
+            <%= relation_form.hidden_field :_destroy %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    <template data-nested-form-target="template">
+      <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove" data-new-record="true">
+        <span data-nested-form-target="capsuleText"></span>
+        <span class="text-xs text-red-500 font-bold">×</span>
+        <%= f.fields_for :relationships, CharacterRelationship.new, child_index: 'NEW_RECORD' do |ff| %>
+          <%= ff.hidden_field :related_character_id, data: { nested_form_target: "hiddenCategoryId" } %>
+          <%= ff.hidden_field :relationship_type, data: { nested_form_target: "hiddenExplanation" } %>
+          <%= ff.hidden_field :_destroy %>
+        <% end %>
+      </div>
+    </template>
+    <div data-nested-form-target="modalPlaceholder"></div>
+  </div>
+
+  <div data-controller="nested-form">
+    <p class="block text-lg font-bold mb-1">特徴</p>
+    <div class="border rounded-lg p-4 mb-2 space-y-2">
+      <select data-nested-form-target="inputType" class="block w-full px-3 py-2 border border-black rounded-md">
+        <option value="">特徴を選択してください</option>
+        <% @feature_categories.each do |category| %>
+          <option value="<%= category.id %>" data-name="<%= category.name %>"><%= category.name %></option>
+        <% end %>
+      </select>
+      <input type="text" data-nested-form-target="inputExplanation" class="block w-full px-3 py-2 border border-black rounded-md" placeholder="説明を記入してください">
+      <button type="button" data-action="click->nested-form#add" class="border border-gray-400 w-full py-2 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300">特徴を追加</button>
+    </div>
+    <div data-nested-form-target="flashContainer" class="mb-4"></div>
+    <div data-nested-form-target="container" class="flex flex-wrap gap-2">
+      <%= f.fields_for :character_features do |feature_form| %>
+        <% unless feature_form.object.new_record? %>
+          <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove">
+            <span><%= feature_form.object.character_feature_category.name %> / <%= feature_form.object.explanation %></span>
+            <span class="text-xs text-red-500 font-bold">×</span>
+            <%= feature_form.hidden_field :id %>
+            <%= feature_form.hidden_field :_destroy %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    <template data-nested-form-target="template">
+      <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove" data-new-record="true">
+        <span data-nested-form-target="capsuleText"></span>
+        <span class="text-xs text-red-500 font-bold">×</span>
+        <%= f.fields_for :character_features, CharacterFeature.new, child_index: 'NEW_RECORD' do |ff| %>
+          <%= ff.hidden_field :character_feature_category_id, data: { nested_form_target: "hiddenCategoryId" } %>
+          <%= ff.hidden_field :explanation, data: { nested_form_target: "hiddenExplanation" } %>
+          <%= ff.hidden_field :_destroy %>
+        <% end %>
+      </div>
+    </template>
+    <div data-nested-form-target="modalPlaceholder"></div>
+  </div>
+
+  <div>
+    <p class="block text-lg font-bold">イメージ画像</p>
+    <div class="flex gap-4 mt-3">
+      <button type="button" disabled class="w-1/2 py-2 border border-gray-400 rounded-md bg-gray-100 text-gray-500">ファイルから画像を追加</button>
+      <button type="button" disabled class="w-1/2 py-2 border border-gray-400 rounded-md bg-gray-100 text-gray-500">イメージ画像を見つける</button>
+    </div>
+  </div>
+
+  <div class="text-center pt-6">
+    <% submit_text = character.new_record? ? "キャラクターを作成する" : "キャラクターを更新する" %>
+    <%= f.submit submit_text, class: "border border-gray-400 px-4 py-3 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300" %>
+  </div>
+
+<% end %>

--- a/app/views/characters/index.html.erb
+++ b/app/views/characters/index.html.erb
@@ -20,21 +20,21 @@
 
     <div class="space-y-10">
       <% @categories.each do |category_key| %>
-        <% category_name = Character.categories[category_key] %>
+        <% category_name = t("enums.character.category.#{category_key}") %>
         <div>
           <div class="flex items-center gap-8 mb-8">
             <h2 class="text-3xl font-bold border-l-8 border-black pl-4"><%= category_name %></h2>
-            <%= link_to "追加", "#", class: "border border-gray-400 px-4 py-1 gap-6 rounded-md font-semibold hover:bg-black hover:text-white" %>
+            <%= link_to "追加", new_story_character_path(@story, character: { category: category_key }), class: "border border-gray-400 px-4 py-1 gap-6 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300" %>
           </div>
           <div class="pl-8 flex flex-wrap gap-3">
             <% if @grouped_characters[category_key] %>
               <% @grouped_characters[category_key].each do |character| %>
-                <span class="px-4 py-1.5 text-md bg-gray-100 border border-black rounded-full"><%= character.name %></span>
+                <%= link_to character.name, story_character_path(@story, character), class: "px-4 py-1.5 text-md bg-gray-100 border border-black rounded-full hover:bg-gray-200 transition-colors duration-200" %>
               <% end %>
             <% else %>
               <p class="text-gray-500">まだ登録されていません。</p>
             <% end %>
-          </div>
+          </div> 
         </div>
       <% end %>
     </div>

--- a/app/views/characters/new.html.erb
+++ b/app/views/characters/new.html.erb
@@ -1,0 +1,7 @@
+<% breadcrumb :new_character, @story %>
+<div class="max-w-3xl mx-auto py-12 px-4">
+  <h1 class="text-center text-4xl font-bold tracking-tight mb-12">キャラクターを作成しよう！</h1>
+  <div class="p-8">
+    <%= render 'form', story: @story, character: @character %>
+  </div>
+</div>

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -1,0 +1,90 @@
+<% breadcrumb :character, @story, @character %>
+<div class="px-4 sm:px-6 lg:px-8 py-8">
+  <div class="max-w-screen-xl mx-auto">
+    <h1 class="text-center text-4xl font-bold tracking-tight mt-12 mb-14">キャラクターを確認しよう！</h1>
+
+    <div class="flex justify-center items-center gap-4 mb-12">
+      <%= link_to "キャラクターを編集する", "#", class: "border border-gray-400 px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors duration-300" %>
+      <%= link_to "キャラクターを削除する", story_character_path(@story, @character), data: { turbo_method: :delete, turbo_confirm: "「#{@character.name}」を完全に削除します。よろしいですか？" }, class: "border border-gray-400 px-8 py-3 rounded-md font-semibold hover:bg-red-500 hover:text-white transition-colors duration-300" %>
+    </div>
+    
+    <div class="max-w-3xl mx-auto space-y-6 border-2 border-gray-300 p-8 rounded-lg bg-white shadow">
+      <div>
+        <p class="font-bold">【キャラクター名】</p>
+        <p class="text-xl ml-4 mt-2"><%= @character.name %></p>
+      </div>
+      <div>
+        <p class="font-bold">【種族】</p>
+        <p class="text-xl ml-4 mt-2"><%= @character.race.presence || "未設定" %></p>
+      </div>
+      <div>
+        <p class="font-bold">【性別】</p>
+        <% if @character.gender.present? %>
+          <p class="text-xl ml-4 mt-2"><%= t("enums.character.gender.#{@character.gender}", default: "翻訳キーが見つかりません") %></p>
+        <% else %>
+          <p class="text-xl ml-4 mt-2">未設定</p>
+        <% end %>
+      </div>
+      <div>
+        <p class="font-bold">【年齢】</p>
+        <p class="text-xl ml-4 mt-2"><%= @character.age.presence || "未設定" %></p>
+      </div>
+      <div>
+        <p class="font-bold">【出身地】</p>
+        <div class="ml-4 mt-2">
+          <% if @character.birthplace_world_guide %>
+            <%= link_to @character.birthplace_world_guide.country_and_region, story_world_guide_path(@story, @character.birthplace_world_guide), class: "inline-block px-3 py-1 text-md bg-gray-100 border border-black rounded-full hover:bg-gray-200" %>
+          <% else %>
+            <p>未設定</p>
+          <% end %>
+        </div>
+      </div>
+      <div>
+        <p class="font-bold">【現住所】</p>
+        <div class="ml-4 mt-2">
+          <% if @character.address_world_guide %>
+            <%= link_to @character.address_world_guide.country_and_region, story_world_guide_path(@story, @character.address_world_guide), class: "inline-block px-3 py-1 text-md bg-gray-100 border border-black rounded-full hover:bg-gray-200" %>
+          <% else %>
+            <p>未設定</p>
+          <% end %>
+        </div>
+      </div>
+      <div>
+        <p class="font-bold">【関連するキャラクター】</p>
+        <div class="flex flex-wrap gap-3 mt-4 ml-4">
+          <% if @character.relationships.exists? %>
+            <% @character.relationships.each do |relationship| %>
+              <%= link_to story_character_path(@story, relationship.related_character), class: "px-3 py-1 text-md bg-gray-100 border border-black rounded-full hover:bg-gray-200" do %>
+                <%= relationship.related_character.name %> / <%= relationship.relationship_type %>
+              <% end %>
+            <% end %>
+          <% else %>
+            <p>なし</p>
+          <% end %>
+        </div>
+      </div>
+      <div>
+        <p class="font-bold">【特徴】</p>
+        <div class="flex flex-wrap gap-3 mt-4 ml-4">
+          <% if @character.character_features.exists? %>
+            <% @character.character_features.each do |feature| %>
+              <span class="px-3 py-1 text-md bg-gray-100 border border-black rounded-full">
+                <%= feature.character_feature_category.name %> / <%= feature.explanation %>
+              </span>
+            <% end %>
+          <% else %>
+            <p>なし</p>
+          <% end %>
+        </div>
+      </div>
+      <div>
+        <p class="font-bold">【イメージ画像】</p>
+        <p class="ml-4 mt-2">なし</p>
+      </div>
+    </div>
+    
+    <div class="text-center mt-12">
+      <%= link_to "キャラクター一覧に戻る", story_characters_path(@story), class: "bg-black text-white px-8 py-3 rounded-md font-semibold hover:bg-gray-800 transition-colors duration-300" %>
+    </div>
+  </div>
+</div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -46,3 +46,18 @@ crumb :characters do |story|
   link "キャラクター一覧", story_characters_path(story)
   parent :story, story
 end
+
+crumb :new_character do |story|
+  link "キャラクター作成", new_story_character_path(story)
+  parent :characters, story
+end
+
+crumb :character do |story, character|
+  link character.name, story_character_path(story, character)
+  parent :characters, story
+end
+
+crumb :edit_character do |story, character|
+  link "キャラクター編集", edit_story_character_path(story, character)
+  parent :character, story, character
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,28 @@ ja:
         world_name: "「 世界名 」"
         country_name: "「 国名 」"
         region_name: "「 地域名 」"
+      character:
+        name: "名前"
+        race: "種族"
+        gender: "性別"
+        age: "年齢"
+        category: "カテゴリ"
+        birthplace_world_guide_id: "出身地"
+        address_world_guide_id: "現住所"
+        
+  
+  enums:
+    character:
+      category:
+        present: "現在"
+        future: "未来"
+        past: "過去"
+        fantasy: "空想"
+      gender:
+        male: "男性"
+        female: "女性"
+        other: "その他"
+        unknown: "不明"
         
   time:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     end
     resources :plots, only: [ :new, :create, :edit, :update, :destroy ]
     resources :world_guides, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
-    resources :characters, only: [ :index, :new, :create ]
+    resources :characters, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
   end
 
   root "home#index"

--- a/db/migrate/20250627090001_create_character_feature_categories.rb
+++ b/db/migrate/20250627090001_create_character_feature_categories.rb
@@ -1,0 +1,9 @@
+class CreateCharacterFeatureCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :character_feature_categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250627090110_create_character_features.rb
+++ b/db/migrate/20250627090110_create_character_features.rb
@@ -1,0 +1,11 @@
+class CreateCharacterFeatures < ActiveRecord::Migration[7.2]
+  def change
+    create_table :character_features do |t|
+      t.string :explanation
+      t.references :character, null: false, foreign_key: true
+      t.references :character_feature_category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250627090137_create_character_relationships.rb
+++ b/db/migrate/20250627090137_create_character_relationships.rb
@@ -1,0 +1,11 @@
+class CreateCharacterRelationships < ActiveRecord::Migration[7.1]
+  def change
+    create_table :character_relationships do |t|
+      t.string :relationship_type
+      t.references :character, null: false, foreign_key: true
+      t.references :related_character, null: false, foreign_key: { to_table: :characters }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250627100017_change_character_columns_to_integer.rb
+++ b/db/migrate/20250627100017_change_character_columns_to_integer.rb
@@ -1,0 +1,6 @@
+class ChangeCharacterColumnsToInteger < ActiveRecord::Migration[7.2]
+  def change
+    change_column :characters, :category, 'integer USING CAST(category AS integer)'
+    change_column :characters, :gender, 'integer USING CAST(gender AS integer)'
+  end
+end

--- a/db/migrate/20250627111012_change_category_to_integer_in_characters.rb
+++ b/db/migrate/20250627111012_change_category_to_integer_in_characters.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryToIntegerInCharacters < ActiveRecord::Migration[7.2]
+  def change
+    change_column :characters, :category, :integer, using: 'category::integer'
+  end
+end

--- a/db/migrate/20250627112313_change_category_to_string_in_characters.rb
+++ b/db/migrate/20250627112313_change_category_to_string_in_characters.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryToStringInCharacters < ActiveRecord::Migration[7.2]
+  def change
+    change_column :characters, :category, :string
+  end
+end

--- a/db/migrate/20250628020342_change_gender_type_in_characters.rb
+++ b/db/migrate/20250628020342_change_gender_type_in_characters.rb
@@ -1,0 +1,5 @@
+class ChangeGenderTypeInCharacters < ActiveRecord::Migration[7.2]
+  def change
+    change_column :characters, :gender, :integer, using: 'gender::integer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_27_074958) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_28_020342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "character_feature_categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "character_features", force: :cascade do |t|
+    t.string "explanation"
+    t.bigint "character_id", null: false
+    t.bigint "character_feature_category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["character_feature_category_id"], name: "index_character_features_on_character_feature_category_id"
+    t.index ["character_id"], name: "index_character_features_on_character_id"
+  end
+
+  create_table "character_relationships", force: :cascade do |t|
+    t.string "relationship_type"
+    t.bigint "character_id", null: false
+    t.bigint "related_character_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["character_id"], name: "index_character_relationships_on_character_id"
+    t.index ["related_character_id"], name: "index_character_relationships_on_related_character_id"
+  end
 
   create_table "characters", force: :cascade do |t|
     t.string "name"
     t.string "race"
-    t.string "gender"
+    t.integer "gender"
     t.string "age"
     t.string "category"
     t.bigint "story_id", null: false
@@ -99,6 +125,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_27_074958) do
     t.index ["story_id"], name: "index_world_guides_on_story_id"
   end
 
+  add_foreign_key "character_features", "character_feature_categories"
+  add_foreign_key "character_features", "characters"
+  add_foreign_key "character_relationships", "characters"
+  add_foreign_key "character_relationships", "characters", column: "related_character_id"
   add_foreign_key "characters", "stories"
   add_foreign_key "characters", "world_guides", column: "address_world_guide_id"
   add_foreign_key "characters", "world_guides", column: "birthplace_world_guide_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,3 +8,14 @@ feature_categories.each do |cat_name|
 end
 
 puts '...World Feature Categories recreated!'
+
+puts 'Creating Character Feature Categories...'
+
+CharacterFeatureCategory.destroy_all
+
+character_feature_categories = [ "性格", "身長", "体重", "髪型", "髪色", "目の色", "肌の色", "武器", "思想", "宗教", "能力", "特技", "服装", "言語", "癖", "その他" ]
+character_feature_categories.each do |cat_name|
+  CharacterFeatureCategory.create!(name: cat_name)
+end
+
+puts '...Character Feature Categories created!'

--- a/test/fixtures/character_feature_categories.yml
+++ b/test/fixtures/character_feature_categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/character_features.yml
+++ b/test/fixtures/character_features.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  explanation: MyString
+  character: one
+  character_feature_category: one
+
+two:
+  explanation: MyString
+  character: two
+  character_feature_category: two

--- a/test/fixtures/character_relationships.yml
+++ b/test/fixtures/character_relationships.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  relationship_type: MyString
+  character: one
+  related_character: one
+
+two:
+  relationship_type: MyString
+  character: two
+  related_character: two

--- a/test/models/character_feature_category_test.rb
+++ b/test/models/character_feature_category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CharacterFeatureCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/character_feature_test.rb
+++ b/test/models/character_feature_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CharacterFeatureTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/character_relationship_test.rb
+++ b/test/models/character_relationship_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CharacterRelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
キャラクター作成、詳細ページを実装しました。

## 内容
- キャラクター作成ページを実装しました。
- 作成ページの特徴、関連するキャラクターを削除時にモーダルが出るようにしました。
- キャラクター詳細ページを実装しました。
- 詳細ページの住所、出身地ではワールドタイプに、関連するキャラクターの要素では該当キャラクターの詳細ページに遷移するようにしました。
