### PR TITLE
add:フラグ一覧ページ実装

### DIFF
--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -1,0 +1,14 @@
+class FlagsController < ApplicationController
+  before_action :require_login
+  before_action :set_story
+
+  def index
+    @flags = @story.flags.order(:created_at)
+  end
+
+  private
+
+  def set_story
+    @story = current_user.stories.find(params[:story_id])
+  end
+end

--- a/app/helpers/flags_helper.rb
+++ b/app/helpers/flags_helper.rb
@@ -1,0 +1,2 @@
+module FlagsHelper
+end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,0 +1,9 @@
+class Flag < ApplicationRecord
+  belongs_to :story
+  has_many :plot_flags, dependent: :destroy
+  has_many :plots, through: :plot_flags
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :check_created, inclusion: { in: [ true, false ] }
+  validates :check_recovered, inclusion: { in: [ true, false ] }
+end

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -4,6 +4,8 @@ class Plot < ApplicationRecord
   has_many :world_guides, through: :plot_world_guides
   has_many :plot_characters, dependent: :destroy
   has_many :characters, through: :plot_characters
+  has_many :plot_flags, dependent: :destroy
+  has_many :flags, through: :plot_flags
 
   validates :chapter, presence: true, length: { maximum: 10 }
   validates :title, length: { maximum: 30 }

--- a/app/models/plot_flag.rb
+++ b/app/models/plot_flag.rb
@@ -1,0 +1,6 @@
+class PlotFlag < ApplicationRecord
+  belongs_to :plot
+  belongs_to :flag
+
+  validates :flag_id, uniqueness: { scope: :plot_id }
+end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -3,6 +3,7 @@ class Story < ApplicationRecord
   belongs_to :user
   has_many :plots, dependent: :destroy
   has_many :world_guides, dependent: :destroy
+  has_many :flags, dependent: :destroy
 
   has_many :characters, dependent: :destroy
 

--- a/app/views/characters/index.html.erb
+++ b/app/views/characters/index.html.erb
@@ -12,7 +12,7 @@
         <a href="<%= story_characters_path(@story) %>" class="border-black text-black whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg" aria-current="page">
           キャラクター
         </a>
-        <a href="#" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
+        <a href="<%= story_flags_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
           フラグ
         </a>
       </nav>

--- a/app/views/flags/index.html.erb
+++ b/app/views/flags/index.html.erb
@@ -1,0 +1,52 @@
+<% breadcrumb :flags, @story %>
+<div class="px-4 sm:px-6 lg:px-8 py-8">
+  <div class="max-w-screen-xl mx-auto">
+    <div class="mb-14">
+      <nav class="-mb-px flex justify-center space-x-8" aria-label="Tabs">
+        <a href="<%= story_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
+          ストーリー
+        </a>
+        <a href="<%= story_world_guides_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
+          ワールドガイド
+        </a>
+        <a href="<%= story_characters_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
+          キャラクター
+        </a>
+        <a href="<%= story_flags_path(@story) %>" class="border-black text-black whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg" aria-current="page">
+          フラグ
+        </a>
+      </nav>
+    </div>
+
+    <div class="space-y-6">
+      <div class="text-center">
+        <%= link_to "フラグを作成する", "#", class: "inline-block border border-gray-400 px-8 py-2 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300" %>
+      </div>
+
+      <div class="space-y-4">
+        <% if @flags.any? %>
+          <% @flags.each do |flag| %>
+            <div class="flex items-center gap-4 p-4 border rounded-lg shadow-sm bg-white">
+              <div class="flex flex-col items-center">
+                <%= check_box_tag "check_created_#{flag.id}", 1, flag.check_created, disabled: true, class: "h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+                <label for="check_created_#{flag.id}" class="text-xs font-bold text-gray-500">P</label>
+              </div>
+              <div class="flex flex-col items-center">
+                <%= check_box_tag "check_recovered_#{flag.id}", 1, flag.check_recovered, disabled: true, class: "h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+                <label for="check_recovered_#{flag.id}" class="text-xs font-bold text-gray-500">I</label>
+              </div>
+              <div class="flex-grow">
+                <%= link_to flag.title, "#", class: "font-semibold text-gray-800 hover:text-black" %>
+              </div>
+              <div class="flex-shrink-0">
+                <%= link_to "編集", "#", class: "text-sm font-medium text-indigo-600 hover:text-indigo-900" %>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="text-center text-gray-500 py-10">まだフラグはありません。</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -24,7 +24,7 @@
           <a href="<%= story_characters_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
             キャラクター
           </a>
-          <a href="#" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
+          <a href="<%= story_flags_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
             フラグ
           </a>
         </nav>

--- a/app/views/world_guides/index.html.erb
+++ b/app/views/world_guides/index.html.erb
@@ -13,7 +13,7 @@
         <a href="<%= story_characters_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
           キャラクター
         </a>
-        <a href="#" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
+        <a href="<%= story_flags_path(@story) %>" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-400 whitespace-nowrap py-4 px-1 border-b-2 font-semibold text-lg">
           フラグ
         </a>
       </nav>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -61,3 +61,8 @@ crumb :edit_character do |story, character|
   link "キャラクター編集", edit_story_character_path(story, character)
   parent :character, story, character
 end
+
+crumb :flags do |story|
+  link "フラグ一覧", story_flags_path(story)
+  parent :story, story
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     resources :plots, only: [ :new, :create, :edit, :update, :destroy ]
     resources :world_guides, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
     resources :characters, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
+    resources :flags, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
   end
 
   root "home#index"

--- a/db/migrate/20250628073047_create_flags.rb
+++ b/db/migrate/20250628073047_create_flags.rb
@@ -1,0 +1,13 @@
+class CreateFlags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :flags do |t|
+      t.references :story, null: false, foreign_key: true
+      t.string :title
+      t.text :content
+      t.boolean :check_created, default: false, null: false
+      t.boolean :check_recovered, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250628073106_create_plot_flags.rb
+++ b/db/migrate/20250628073106_create_plot_flags.rb
@@ -1,0 +1,11 @@
+class CreatePlotFlags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :plot_flags do |t|
+      t.references :plot, null: false, foreign_key: true
+      t.references :flag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :plot_flags, [ :plot_id, :flag_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_28_060451) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_28_073106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_28_060451) do
     t.index ["story_id"], name: "index_characters_on_story_id"
   end
 
+  create_table "flags", force: :cascade do |t|
+    t.bigint "story_id", null: false
+    t.string "title"
+    t.text "content"
+    t.boolean "check_created"
+    t.boolean "check_recovered"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_id"], name: "index_flags_on_story_id"
+  end
+
   create_table "plot_characters", force: :cascade do |t|
     t.bigint "plot_id", null: false
     t.bigint "character_id", null: false
@@ -64,6 +75,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_28_060451) do
     t.index ["character_id"], name: "index_plot_characters_on_character_id"
     t.index ["plot_id", "character_id"], name: "index_plot_characters_on_plot_id_and_character_id", unique: true
     t.index ["plot_id"], name: "index_plot_characters_on_plot_id"
+  end
+
+  create_table "plot_flags", force: :cascade do |t|
+    t.bigint "plot_id", null: false
+    t.bigint "flag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["flag_id"], name: "index_plot_flags_on_flag_id"
+    t.index ["plot_id", "flag_id"], name: "index_plot_flags_on_plot_id_and_flag_id", unique: true
+    t.index ["plot_id"], name: "index_plot_flags_on_plot_id"
   end
 
   create_table "plot_world_guides", force: :cascade do |t|
@@ -142,8 +163,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_28_060451) do
   add_foreign_key "characters", "stories"
   add_foreign_key "characters", "world_guides", column: "address_world_guide_id"
   add_foreign_key "characters", "world_guides", column: "birthplace_world_guide_id"
+  add_foreign_key "flags", "stories"
   add_foreign_key "plot_characters", "characters"
   add_foreign_key "plot_characters", "plots"
+  add_foreign_key "plot_flags", "flags"
+  add_foreign_key "plot_flags", "plots"
   add_foreign_key "plot_world_guides", "plots"
   add_foreign_key "plot_world_guides", "world_guides"
   add_foreign_key "plots", "stories"

--- a/test/controllers/flags_controller_test.rb
+++ b/test/controllers/flags_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FlagsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/flags.yml
+++ b/test/fixtures/flags.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  story: one
+  title: MyString
+  content: MyText
+  check_created: false
+  check_recovered: false
+
+two:
+  story: two
+  title: MyString
+  content: MyText
+  check_created: false
+  check_recovered: false

--- a/test/fixtures/plot_flags.yml
+++ b/test/fixtures/plot_flags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  plot: one
+  flag: one
+
+two:
+  plot: two
+  flag: two

--- a/test/models/flag_test.rb
+++ b/test/models/flag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FlagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/plot_flag_test.rb
+++ b/test/models/plot_flag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PlotFlagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
フラグ一覧ページを実装しました

## 内容
- ストーリー詳細ページ、ワールドガイド一覧ページ、キャラクター一覧ページのタグより遷移できるようにしました。
- コントローラ、モデル、ビューの設定を行いました。
- ボタン（リンクなし）、パンくずの設定を行いました。