### PR TITLE
add-フラグとプロットモデル、コントローラの修正

### DIFF
--- a/app/controllers/plots_controller.rb
+++ b/app/controllers/plots_controller.rb
@@ -7,6 +7,7 @@ class PlotsController < ApplicationController
     @plot = @story.plots.build
     @world_guides = @story.world_guides.order(:created_at)
     @characters = @story.characters.order(:created_at)
+    @flags_for_select = @story.flags.unrecovered.order(:created_at)
   end
 
   def create
@@ -16,6 +17,7 @@ class PlotsController < ApplicationController
     else
       @world_guides = @story.world_guides.order(:created_at)
       @characters = @story.characters.order(:created_at)
+      @flags_for_select = @story.flags.unrecovered.order(:created_at)
       flash.now[:error] = "プロットの作成に失敗しました。"
       render :new, status: :unprocessable_entity
     end
@@ -24,6 +26,7 @@ class PlotsController < ApplicationController
   def edit
     @world_guides = @story.world_guides.order(:created_at)
     @characters = @story.characters.order(:created_at)
+    @flags_for_select = @story.flags.unrecovered.order(:created_at)
   end
 
   def update
@@ -32,6 +35,7 @@ class PlotsController < ApplicationController
     else
       @world_guides = @story.world_guides.order(:created_at)
       @characters = @story.characters.order(:created_at)
+      @flags_for_select = @story.flags.unrecovered.order(:created_at)
       flash.now[:error] = "プロットの更新に失敗しました。"
       render :edit, status: :unprocessable_entity
     end
@@ -53,6 +57,11 @@ class PlotsController < ApplicationController
   end
 
   def plot_params
-    params.require(:plot).permit(:chapter, :title, :summary, :content, :order, world_guide_ids: [], character_ids: [])
+    params.require(:plot).permit(
+      :chapter, :title, :summary, :content, :order,
+      world_guide_ids: [],
+      character_ids: [],
+      plot_flags_attributes: [ :id, :flag_id, :check_created, :check_recovered, :_destroy ]
+    )
   end
 end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -6,6 +6,14 @@ class Flag < ApplicationRecord
   validates :title, presence: true, length: { maximum: 30 }
   validates :content, presence: true
 
+   scope :unrecovered, -> {
+    where.not(id: joins(:plot_flags).where(plot_flags: { check_recovered: true }))
+  }
+
+  def already_created_in_story?
+    story.plot_flags.where(flag_id: id, check_created: true).exists?
+  end
+
   def created?
     plot_flags.any?(&:check_created)
   end

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -7,6 +7,8 @@ class Plot < ApplicationRecord
   has_many :plot_flags, dependent: :destroy
   has_many :flags, through: :plot_flags
 
+  accepts_nested_attributes_for :plot_flags, allow_destroy: true
+
   validates :chapter, presence: true, length: { maximum: 10 }
   validates :title, length: { maximum: 30 }
   validates :summary, length: { maximum: 30 }


### PR DESCRIPTION
## 概要
フラグとプロットを連携するため、フラグモデルとプロットモデル、プロットコントローラを修正しました。
（バックエンド）