### PR TITLE
fix-Renderでのマイグレーションエラー改善

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ ENTRYPOINT ["render-entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ["bash", "-c", "bundle exec rails db:migrate && rm -f tmp/pids/server.pid && bundle exec rails s -b '0.0.0.0'"]
+CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]
+

--- a/bin/render-entrypoint.sh
+++ b/bin/render-entrypoint.sh
@@ -2,7 +2,9 @@
 # exit on error
 set -o errexit
 
+rm -f /app/tmp/pids/server.pid
+
+echo "Running database migrations..."
 bundle exec rails db:migrate
-bundle exec rails db:seed
 
 exec "$@"


### PR DESCRIPTION
## 概要
Renderにて、データベースにあるplot_flagsテーブルを探したが、check_recoveredというカラムが見つからないというエラーが出たため、db:migrateをするよう書き換えました。