### PR TITLE
fix-Renderでのマイグレーションエラー改善2

### DIFF
--- a/bin/render-entrypoint.sh
+++ b/bin/render-entrypoint.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 rm -f /app/tmp/pids/server.pid
 
-echo "Running database migrations..."
-bundle exec rails db:migrate
+echo "Setting up the database..."
+bundle exec rails db:setup
 
 exec "$@"


### PR DESCRIPTION
## 概要
Renderでのデータベースが見つからないエラーが治っていないため再度修正します。

## 内容
- bin/render-entrypoint.shをもとに戻します（データベースを再構築）