### PR TITLE
update-ログイン認証

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -66,7 +66,11 @@ class CharactersController < ApplicationController
   end
 
   def set_character
-    @character = @story.characters.find(params[:id])
+    @character = @story.characters.find_by(id: params[:id])
+    unless @character
+      flash[:error] = "キャラクターは存在しません。"
+      redirect_to story_characters_path(@story)
+    end
   end
 
   def character_params

--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -48,7 +48,11 @@ class FlagsController < ApplicationController
   end
 
   def set_flag
-    @flag = @story.flags.includes(plot_flags: :plot).find(params[:id])
+    @flag = @story.flags.includes(plot_flags: :plot).find_by(id: params[:id])
+    unless @flag
+      flash[:error] = "フラグは存在しません。"
+      redirect_to story_flags_path(@story)
+    end
   end
 
   def flag_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :omniauth
   def omniauth
     auth = request.env["omniauth.auth"]
 
@@ -9,13 +10,15 @@ class SessionsController < ApplicationController
 
     session[:user_id] = user.id
 
-    redirect_to stories_path
+    redirect_to stories_path, notice: "ログインしました。"
   rescue => e
     logger.error "OAuth認証エラー: #{e.message}"
     redirect_to root_path, alert: "ログインに失敗しました。"
   end
 
   def auth_failure
+    session[:user_id] = nil
+
     message = params[:message] || "認証に失敗しました。"
     logger.error "OmniAuth Authentication Failure: #{message}"
     redirect_to root_path, alert: "Googleログインに失敗しました: #{message}"

--- a/app/controllers/world_guides_controller.rb
+++ b/app/controllers/world_guides_controller.rb
@@ -51,7 +51,11 @@ class WorldGuidesController < ApplicationController
   end
 
   def set_world_guide
-    @world_guide = @story.world_guides.find(params[:id])
+    @world_guide = @story.world_guides.find_by(id: params[:id])
+    unless @world_guide
+      flash[:error] = "ワールドガイドは存在しません。"
+      redirect_to story_world_guides_path(@story)
+    end
   end
 
   def world_guide_params

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,11 +1,16 @@
 OmniAuth.config.allowed_request_methods = [ :get, :post ]
 
+OmniAuth.config.on_failure = Proc.new { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
     scope: "email,profile",
     prompt: "select_account",
     image_aspect_ratio: "square",
     image_size: 50,
-    access_type: "offline"
+    access_type: "offline",
+    callback_path: "/auth/google_oauth2/callback"
   }
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+Rails.application.config.session_store :cookie_store,
+                                       key: "_historia_session",
+                                       samesite: :lax,
+                                       secure: Rails.env.production?


### PR DESCRIPTION
## 概要
Google認証の挙動エラーを直しました。

## 内容
エラーが出る挙動：
Google認証をしてログインに成功 ⇒ ログイン後のページで戻る動作を行う ⇒ Google認証のアカウント選択画面に戻る ⇒ アカウント選択するとCSRFエラーがでる

上記改善し、フラッシュメッセージでログインできなかった旨を伝え、ログイン前ページに遷移するようにしました。