### PR TITLE
fix-ストーリー削除時のエラー改善

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -53,6 +53,9 @@ class StoriesController < ApplicationController
 
   def set_story
     @story = current_user.stories.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:alert] = "お探しのストーリーは存在しないか、削除された可能性があります。"
+    redirect_to stories_path
   end
 
   def story_params


### PR DESCRIPTION
## 概要
ストーリー詳細⇒ 削除 ⇒ 削除成功 ⇒ 戻る ⇒ストーリーが存在しないためエラーの挙動を直しました。