### PR TITLE
fix-バリデーションエラーで特徴削除

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -24,6 +24,7 @@ class CharactersController < ApplicationController
       redirect_to story_characters_path(@story), success: "キャラクターを追加しました。"
     else
       flash.now[:error] = "キャラクターの作成に失敗しました。"
+      @validation_error = true
       render :new, status: :unprocessable_entity
     end
   end
@@ -36,6 +37,7 @@ class CharactersController < ApplicationController
       redirect_to story_character_path(@story, @character), success: "キャラクターを更新しました。"
     else
       flash.now[:error] = "キャラクターの更新に失敗しました。"
+      @validation_error = true
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/world_guides_controller.rb
+++ b/app/controllers/world_guides_controller.rb
@@ -2,6 +2,7 @@ class WorldGuidesController < ApplicationController
   before_action :require_login
   before_action :set_story
   before_action :set_world_guide, only: [ :show, :edit, :update, :destroy ]
+  before_action :prepare_form_data, only: [ :new, :create, :edit, :update ]
 
   def index
     @world_guides = @story.world_guides.order(:created_at)
@@ -26,6 +27,7 @@ class WorldGuidesController < ApplicationController
       redirect_to story_world_guides_path(@story), success: "ワールドガイドを追加しました。"
     else
       flash.now[:error] = "ワールドガイドの作成に失敗しました。"
+      @validation_error = true
       render :new, status: :unprocessable_entity
     end
   end
@@ -35,6 +37,7 @@ class WorldGuidesController < ApplicationController
       redirect_to story_world_guide_path(@story, @world_guide), success: "ワールドガイドを更新しました。"
     else
       flash.now[:error] = "ワールドガイドの更新に失敗しました。"
+      @validation_error = true
       render :edit, status: :unprocessable_entity
     end
   end
@@ -56,6 +59,10 @@ class WorldGuidesController < ApplicationController
       flash[:error] = "ワールドガイドは存在しません。"
       redirect_to story_world_guides_path(@story)
     end
+  end
+
+  def prepare_form_data
+    @feature_categories = WorldFeatureCategory.order(:id)
   end
 
   def world_guide_params

--- a/app/views/characters/_form.html.erb
+++ b/app/views/characters/_form.html.erb
@@ -1,6 +1,14 @@
 <%= form_with model: [story, character], local: true, class: "space-y-8" do |f| %>
   <%= render 'characters/forms/error_messages', character: character %>
 
+  <% if character.errors.any? %>
+    <div id="form-validation-error-trigger" 
+         class="hidden"
+         data-features="<%= character.character_features.to_json(only: [:id, :character_feature_category_id, :explanation]) %>"
+         data-relationships="<%= character.relationships.to_json(only: [:id, :related_character_id, :relationship_type]) %>">
+    </div>
+  <% end %>
+
   <%= render 'characters/forms/basic_info_fields', f: f %>
 
   <%= render 'characters/forms/location_fields', f: f, world_guides: @world_guides %>

--- a/app/views/characters/forms/_features_fields.html.erb
+++ b/app/views/characters/forms/_features_fields.html.erb
@@ -1,7 +1,6 @@
-<div data-controller="nested-form"
-    data-nested-form-modal-title-value="特徴の削除"
-    data-nested-form-modal-message-value="この特徴を削除しますか？">
+<div data-controller="nested-form" data-form-type="features" data-nested-form-modal-title-value="特徴の削除" data-nested-form-modal-message-value="この特徴を削除しますか？">
   <p class="block text-lg font-bold mb-1">特徴</p>
+
   <div class="border rounded-lg p-4 mb-2 space-y-2">
     <select data-nested-form-target="inputType" class="block w-full px-3 py-2 border border-black rounded-md">
       <option value="">特徴を選択してください。</option>
@@ -9,12 +8,13 @@
         <option value="<%= category.id %>" data-name="<%= category.name %>"><%= category.name %></option>
       <% end %>
     </select>
-
     <input type="text" data-nested-form-target="inputExplanation" class="block w-full px-3 py-2 border border-black rounded-md" placeholder="説明を25文字以内で記入してください。" maxlength="25">
     <button type="button" data-action="click->nested-form#add" class="border border-gray-400 w-full py-2 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300">特徴を追加</button>
   </div>
+  
   <div data-nested-form-target="flashContainer" class="mb-4"></div>
-  <div data-nested-form-target="container" class="flex flex-wrap gap-2">
+
+  <div class="flex flex-wrap gap-2">
     <%= f.fields_for :character_features do |feature_form| %>
       <% unless feature_form.object.new_record? %>
         <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove">
@@ -25,7 +25,10 @@
         </div>
       <% end %>
     <% end %>
+
+    <div data-nested-form-target="container" class="contents"></div>
   </div>
+
   <template data-nested-form-target="template">
     <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove" data-new-record="true">
       <span data-nested-form-target="capsuleText"></span>

--- a/app/views/characters/forms/_relationships_fields.html.erb
+++ b/app/views/characters/forms/_relationships_fields.html.erb
@@ -1,7 +1,6 @@
-<div data-controller="nested-form"
-   data-nested-form-modal-title-value="関連キャラクターの削除"
-   data-nested-form-modal-message-value="この関連キャラクターを削除しますか？">
+<div data-controller="nested-form" data-form-type="relationships" data-nested-form-modal-title-value="関連キャラクターの削除" data-nested-form-modal-message-value="この関連キャラクターを削除しますか？">
   <p class="block text-lg font-bold mb-1">関連するキャラクター</p>
+  
   <div class="border rounded-lg p-4 mb-2 space-y-2">
     <select data-nested-form-target="inputType" class="block w-full px-3 py-2 border border-black rounded-md">
       <option value="">キャラクターを選択してください。</option>
@@ -12,8 +11,10 @@
     <input type="text" data-nested-form-target="inputExplanation" class="block w-full px-3 py-2 border border-black rounded-md" placeholder="関係性を25文字以内で記入してください。（例：友人、男友達で一番仲がいい）" maxlength="25">
     <button type="button" data-action="click->nested-form#add" class="border border-gray-400 w-full py-2 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300">関係性を追加</button>
   </div>
+  
   <div data-nested-form-target="flashContainer" class="mb-4"></div>
-  <div data-nested-form-target="container" class="flex flex-wrap gap-2">
+
+  <div class="flex flex-wrap gap-2">
     <%= f.fields_for :relationships do |relation_form| %>
       <% unless relation_form.object.new_record? %>
         <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove">
@@ -24,7 +25,10 @@
         </div>
       <% end %>
     <% end %>
+
+    <div data-nested-form-target="container" class="contents"></div>
   </div>
+
   <template data-nested-form-target="template">
     <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove" data-new-record="true">
       <span data-nested-form-target="capsuleText"></span>

--- a/app/views/world_guides/_feature_fields.html.erb
+++ b/app/views/world_guides/_feature_fields.html.erb
@@ -1,20 +1,20 @@
-<div>
+<div data-controller="nested-form" data-form-type="worldGuideFeatures" data-nested-form-modal-title-value="特徴の削除" data-nested-form-modal-message-value="この特徴を削除しますか？">
   <p class="block text-lg font-bold mb-2">特徴</p>
 
-  <div class="border rounded-lg p-4 mb-4 space-y-2">
+  <div class="border rounded-lg p-4 mb-2 space-y-2">
     <select data-nested-form-target="inputType" class="block w-full px-3 py-2 border border-black rounded-md">
       <option value="">特徴を選択してください。</option>
-      <% WorldFeatureCategory.all.each do |category| %>
+      <% @feature_categories.each do |category| %>
         <option value="<%= category.id %>" data-name="<%= category.name %>"><%= category.name %></option>
       <% end %>
     </select>
     <input type="text" data-nested-form-target="inputExplanation" class="block w-full px-3 py-2 border border-black rounded-md" placeholder="25文字以内で説明を記入してください。" maxlength="25">
     <button type="button" data-action="click->nested-form#add" class="border border-gray-400 w-full py-2 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300">特徴を追加</button>
   </div>
-    
+  
   <div data-nested-form-target="flashContainer" class="mb-4"></div>
 
-  <div data-nested-form-target="container" class="flex flex-wrap gap-2">
+  <div class="flex flex-wrap gap-2">
     <%= f.fields_for :world_guide_features do |feature_form| %>
       <% unless feature_form.object.new_record? %>
         <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-md bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove">
@@ -25,18 +25,20 @@
         </div>
       <% end %>
     <% end %>
-  </div>
-</div>
 
-<template data-nested-form-target="template">
-  <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-semimd bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove" data-new-record="true">
-    <span data-nested-form-target="capsuleText"></span>
-    <span class="text-xs text-red-500 font-bold">×</span>
-      
-        <%= f.fields_for :world_guide_features, WorldGuideFeature.new, child_index: 'NEW_RECORD' do |ff| %>
-      <%= ff.hidden_field :world_feature_category_id, data: { nested_form_target: "hiddenCategoryId" } %>
-      <%= ff.hidden_field :explanation, data: { nested_form_target: "hiddenExplanation" } %>
-      <%= ff.hidden_field :_destroy %>
-    <% end %>
+    <div data-nested-form-target="container" class="contents"></div>
   </div>
-</template>
+
+  <template data-nested-form-target="template">
+    <div class="nested-fields-wrapper inline-flex items-center gap-2 px-3 py-1 text-semimd bg-gray-100 border border-black rounded-full cursor-pointer" data-action="click->nested-form#remove" data-new-record="true">
+      <span data-nested-form-target="capsuleText"></span>
+      <span class="text-xs text-red-500 font-bold">×</span>
+      <%= f.fields_for :world_guide_features, WorldGuideFeature.new, child_index: 'NEW_RECORD' do |ff| %>
+        <%= ff.hidden_field :world_feature_category_id, data: { nested_form_target: "hiddenCategoryId" } %>
+        <%= ff.hidden_field :explanation, data: { nested_form_target: "hiddenExplanation" } %>
+        <%= ff.hidden_field :_destroy %>
+      <% end %>
+    </div>
+  </template>
+  <div data-nested-form-target="modalPlaceholder"></div>
+</div>

--- a/app/views/world_guides/_form.html.erb
+++ b/app/views/world_guides/_form.html.erb
@@ -1,4 +1,11 @@
-<%= form_with model: [story, world_guide], local: true, class: "space-y-8", data: { controller: "nested-form" } do |f| %>
+<%= form_with model: [story, world_guide], local: true, class: "space-y-8" do |f| %>
+
+  <% if @validation_error %>
+    <div id="form-validation-error-trigger" 
+         class="hidden"
+         data-world-guide-features="<%= world_guide.world_guide_features.to_json(only: [:id, :world_feature_category_id, :explanation]) %>">
+    </div>
+  <% end %>
 
   <% if world_guide.errors.any? %>
     <div id="error_explanation" class="text-red-500 border border-red-300 bg-red-50 p-4 rounded-md">
@@ -12,7 +19,6 @@
   <% end %>
 
   <%= render 'world_guides/basic_fields', f: f %>
-
   <%= render 'world_guides/feature_fields', f: f %>
 
   <div>
@@ -28,5 +34,4 @@
     <%= f.submit submit_text, class: "border border-gray-400 px-4 py-3 rounded-md font-semibold hover:bg-black hover:text-white transition-colors duration-300" %>
   </div>
 
-  <div data-nested-form-target="modalPlaceholder"></div>
 <% end %>


### PR DESCRIPTION
## 概要
キャラクター、ワールドガイドで以下のバリデーションエラーで要素が消えるバグを修正しました。

- 作成、編集時タイトルを記載せず（バリデーションエラートリガー）特徴を記載済みのまま作成を押下すると、バリデーションエラーが起こり記載済みの特徴が消える