### PR TITLE
add-使い方ガイド

### DIFF
--- a/app/views/shared/_guide_modal.html.erb
+++ b/app/views/shared/_guide_modal.html.erb
@@ -13,7 +13,7 @@
       <div data-guide-modal-target="page" class="guide-page">
         <h3 class="text-xl font-semibold mb-6">1. ストーリーを作成しよう！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'story_create.mp4' %>"  controls autoplay loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'story_create.mp4' %>"  controls loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>
@@ -24,7 +24,7 @@
       <div data-guide-modal-target="page" class="guide-page hidden">
         <h3 class="text-xl font-semibold mb-6">2. ワールドガイド（物語の舞台）を作成しよう！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'world_guides.mp4' %>"  controls autoplay loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'world_guides.mp4' %>"  controls loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>
@@ -35,7 +35,7 @@
       <div data-guide-modal-target="page" class="guide-page hidden">
         <h3 class="text-xl font-semibold mb-6">3. キャラクター（登場人物）を作成しよう！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'characters.mp4' %>"  controls autoplay loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'characters.mp4' %>"  controls loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>
@@ -46,7 +46,7 @@
       <div data-guide-modal-target="page" class="guide-page hidden">
         <h3 class="text-xl font-semibold mb-6">4. フラグ（伏線）を作成しよう！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'flags.mp4' %>"  controls autoplay loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'flags.mp4' %>"  controls loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>
@@ -57,7 +57,7 @@
       <div data-guide-modal-target="page" class="guide-page hidden">
         <h3 class="text-xl font-semibold mb-6">5. プロットを作成しよう！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'plots.mp4' %>"  controls autoplay loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'plots.mp4' %>"  controls loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>
@@ -71,7 +71,7 @@
       <div data-guide-modal-target="page" class="guide-page hidden">
         <h3 class="text-xl font-semibold mb-6">おまけ. プロットから各詳細ページを確認できるよ！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'historia2.mp4' %>"  controls autoplay loop muted preload="none"playsinline  data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'historia2.mp4' %>"  controls loop muted preload="none" playsinline  data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>
@@ -82,7 +82,7 @@
       <div data-guide-modal-target="page" class="guide-page hidden">
         <h3 class="text-xl font-semibold mb-6">おまけ 2. 作成後のフラグとストーリーの表示を確認しよう！</h3>
         <div class="relative w-full pb-[75%] border border-black border-2 mb-4 rounded-md overflow-hidden">
-          <video src="<%= asset_path 'historia.mp4' %>"  controls autoplay loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
+          <video src="<%= asset_path 'historia.mp4' %>"  controls loop muted preload="none" playsinline data-guide-modal-target="videoElement" class="absolute top-0 left-0 w-full h-full object-cover rounded-md">
             お使いのブラウザは動画タグをサポートしていません。
           </video>
         </div>


### PR DESCRIPTION
## 概要
`autoplay`の記述を外し、JavaScriptだけの指令にすることで重複指令をなくしました。これで動画の複数再生が防げると考えています。